### PR TITLE
Support arbitrary etcd image names

### DIFF
--- a/pkg/apis/etcd/v1beta2/cluster.go
+++ b/pkg/apis/etcd/v1beta2/cluster.go
@@ -23,8 +23,8 @@ import (
 )
 
 const (
-	defaultRepository  = "quay.io/coreos/etcd"
-	DefaultEtcdVersion = "3.2.13"
+	DefaultEtcdRepository = "quay.io/coreos/etcd"
+	DefaultEtcdVersion    = "3.2.13"
 )
 
 var (
@@ -149,6 +149,12 @@ type PodPolicy struct {
 	// More info: https://github.com/docker-library/busybox/issues/27
 	BusyboxImage string `json:"busyboxImage,omitempty"`
 
+	// etcd image name.  If unset behaves as if the value was `${repository}:v${version}`
+	// Some variable expansions will be performed:
+	// ${repository} is replaced with the repository (ClusterSpec.Repository)
+	// ${version} is replaced with the etcd version
+	EtcdImage string `json:"etcdImage,omitempty"`
+
 	// SecurityContext specifies the security context for the entire pod
 	// More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context
 	SecurityContext *v1.PodSecurityContext `json:"securityContext,omitempty"`
@@ -182,7 +188,7 @@ func (c *ClusterSpec) Validate() error {
 func (e *EtcdCluster) SetDefaults() {
 	c := &e.Spec
 	if len(c.Repository) == 0 {
-		c.Repository = defaultRepository
+		c.Repository = DefaultEtcdRepository
 	}
 
 	if len(c.Version) == 0 {

--- a/pkg/cluster/upgrade.go
+++ b/pkg/cluster/upgrade.go
@@ -36,7 +36,7 @@ func (c *Cluster) upgradeOneMember(memberName string) error {
 	oldpod := pod.DeepCopy()
 
 	c.logger.Infof("upgrading the etcd member %v from %s to %s", memberName, k8sutil.GetEtcdVersion(pod), c.cluster.Spec.Version)
-	pod.Spec.Containers[0].Image = k8sutil.ImageName(c.cluster.Spec.Repository, c.cluster.Spec.Version)
+	pod.Spec.Containers[0].Image = k8sutil.ImageName(c.cluster.Spec, c.cluster.Spec.Version)
 	k8sutil.SetEtcdVersion(pod, c.cluster.Spec.Version)
 
 	patchdata, err := k8sutil.CreatePatch(oldpod, pod, v1.Pod{})

--- a/pkg/util/k8sutil/k8sutils_test.go
+++ b/pkg/util/k8sutil/k8sutils_test.go
@@ -47,3 +47,25 @@ func TestSetBusyboxImageName(t *testing.T) {
 		t.Errorf("expect image=%s, get=%s", expected, image)
 	}
 }
+
+func TestDefaultEtcdImageName(t *testing.T) {
+	cs := api.ClusterSpec{Repository: api.DefaultEtcdRepository}
+	image := ImageName(cs, "3.2.13")
+	expected := "quay.io/coreos/etcd:v3.2.13"
+	if image != expected {
+		t.Errorf("expect image=%s, get=%s", expected, image)
+	}
+}
+
+func TestSetEtcdImageName(t *testing.T) {
+	cs := api.ClusterSpec{
+		Pod: &api.PodPolicy{
+			EtcdImage: "private.repository.local/mirror/coreos:etcd-${version}",
+		},
+	}
+	image := ImageName(cs, "3.2.13")
+	expected := "private.repository.local/mirror/coreos:etcd-3.2.13"
+	if image != expected {
+		t.Errorf("expect image=%s, get=%s", expected, image)
+	}
+}

--- a/pkg/util/k8sutil/pod_util.go
+++ b/pkg/util/k8sutil/pod_util.go
@@ -34,11 +34,11 @@ func etcdVolumeMounts() []v1.VolumeMount {
 	}
 }
 
-func etcdContainer(cmd []string, repo, version string) v1.Container {
+func etcdContainer(cmd []string, cs api.ClusterSpec, version string) v1.Container {
 	c := v1.Container{
 		Command: cmd,
 		Name:    "etcd",
-		Image:   ImageName(repo, version),
+		Image:   ImageName(cs, version),
 		Ports: []v1.ContainerPort{
 			{
 				Name:          "server",


### PR DESCRIPTION
The below was the original PR from coreos/etcd-operator - link at https://github.com/coreos/etcd-operator/pull/1970 for further improvements that could be made.

----------------------------------------------------------------

We allow a simple template to be defined in the PodPolicy, and we
perform substitution of the repository and version into that template.
The default template keeps the existing behaviour, so no user changes
should be needed.

This allows for registries that may not follow the same format as
quay.io - for example when mirroring to a private repo for no-internet
installs, the limited depth allowed by docker often means that users
will embed some of the repo name into the image name.


Please read https://github.com/coreos/etcd-operator/blob/master/CONTRIBUTING.md#contribution-flow
