### PR TITLE
Add tmpfs option for etcd-data volume

### DIFF
--- a/pkg/apis/etcd/v1beta2/cluster.go
+++ b/pkg/apis/etcd/v1beta2/cluster.go
@@ -162,6 +162,11 @@ type PodPolicy struct {
 	// '.cluster.local'.
 	// The default is to not set a cluster domain explicitly.
 	ClusterDomain string `json:"ClusterDomain"`
+
+	// Sets the 'emptyDir.medium' field for the etcd-data volume to "Memory".
+	// The default is to not use memory as the storage medium
+	// No effect if persistent volume is used
+	Tmpfs bool `json:"tmpfs,omitempty"`
 }
 
 // TODO: move this to initializer

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -377,9 +377,9 @@ func (c *Cluster) createPod(members etcdutil.MemberSet, m *etcdutil.Member, stat
 		if err != nil {
 			return fmt.Errorf("failed to create PVC for member (%s): %v", m.Name, err)
 		}
-		k8sutil.AddEtcdVolumeToPod(pod, pvc)
+		k8sutil.AddEtcdVolumeToPod(pod, pvc, false)
 	} else {
-		k8sutil.AddEtcdVolumeToPod(pod, nil)
+		k8sutil.AddEtcdVolumeToPod(pod, nil, c.cluster.Spec.Pod.Tmpfs)
 	}
 	_, err := c.config.KubeCli.CoreV1().Pods(c.cluster.Namespace).Create(pod)
 	return err


### PR DESCRIPTION
The second PR from coreos/etcd-operator to be pulled in to this fork.

---------------------------
This adds an additional optional field to the etcdcluster.spec.pod field, allowing etcdpods to use tmpfs for etcd-data.